### PR TITLE
fix(get_fs): drop leading and doubled semicolons in the command string

### DIFF
--- a/R/fs_setup.R
+++ b/R/fs_setup.R
@@ -83,28 +83,37 @@ get_fs <- function(
 
   # Construct the main command string
   if (!add_home) {
-    parts <- c(cmd, sh_file_cmd)
-    parts <- parts[nzchar(parts)]
-    return(paste(parts, collapse = "; "))
+    return(collapse_fs_cmd(c(cmd, sh_file_cmd)))
   }
 
-  paste(
-    c(
-      cmd,
-      sprintf(
-        "export FREESURFER_HOME=%s",
-        shQuote(freesurferdir)
-      ),
-      sh_file_cmd,
-      sprintf(
-        "export FSF_OUTPUT_FORMAT=%s",
-        get_fs_output()
-      ),
-      paste0(start_up_path, "/")
+  collapse_fs_cmd(c(
+    cmd,
+    sprintf(
+      "export FREESURFER_HOME=%s",
+      shQuote(freesurferdir)
     ),
-    collapse = "; ",
-    sep = "; "
-  )
+    sh_file_cmd,
+    sprintf(
+      "export FSF_OUTPUT_FORMAT=%s",
+      get_fs_output()
+    ),
+    paste0(start_up_path, "/")
+  ))
+}
+
+#' Join FreeSurfer command parts into a single shell string
+#'
+#' Drops empty parts and collapses the leading and doubled `;` separators
+#' that arise when an empty leading element or an already-`;`-terminated
+#' part (such as the `source ... || true ; ` env setup) is joined with
+#' `collapse = "; "`. Without this, the assembled command begins with a
+#' stray `;` (a bash syntax error) or contains `; ;` sequences.
+#' @noRd
+collapse_fs_cmd <- function(parts) {
+  parts <- parts[nzchar(parts)]
+  cmd <- paste(parts, collapse = "; ")
+  cmd <- gsub("[[:space:]]*(;[[:space:]]*)+", "; ", cmd)
+  sub("^[[:space:]]*;[[:space:]]*", "", cmd)
 }
 
 

--- a/tests/testthat/test-fs_setup.R
+++ b/tests/testthat/test-fs_setup.R
@@ -56,7 +56,9 @@ describe("get_fs", {
           source = "Default",
           value = "/valid/path"
         )
-        if (simplify) return(ret$value)
+        if (simplify) {
+          return(ret$value)
+        }
         ret
       },
       get_fs_license = function(simplify = FALSE) {
@@ -113,7 +115,9 @@ describe("get_fs", {
     local_mocked_bindings(
       get_fs_home = function(simplify = FALSE) {
         ret <- list(value = "/valid/path", exists = TRUE, source = "Default")
-        if (simplify) return(ret$value)
+        if (simplify) {
+          return(ret$value)
+        }
         ret
       },
       get_fs_license = function(simplify = FALSE) list(exists = TRUE),
@@ -127,11 +131,30 @@ describe("get_fs", {
     expect_false(grepl("source", cmd))
   })
 
+  it("does not emit a leading or doubled semicolon", {
+    local_mocked_bindings(
+      get_fs_home = function(simplify = FALSE) {
+        list(value = "/valid/path", exists = TRUE, source = "Default")
+      },
+      get_fs_license = function(simplify = FALSE) list(exists = TRUE),
+      get_fs_source = function(simplify = FALSE) {
+        list(exists = TRUE, value = "/valid/path/FreeSurferEnv.sh")
+      },
+      get_fs_output = function() "nii"
+    )
+    cmd <- get_fs("bin")
+
+    expect_false(grepl("^[[:space:]]*;", cmd))
+    expect_false(grepl(";[[:space:]]*;", cmd))
+  })
+
   it("errors on invalid bin_app argument", {
     local_mocked_bindings(
       get_fs_home = function(simplify = TRUE) {
         ret <- list(value = "/valid/path", exists = TRUE, source = "Default")
-        if (simplify) return(ret$value)
+        if (simplify) {
+          return(ret$value)
+        }
         ret
       },
       get_fs_license = mock_get_license


### PR DESCRIPTION
## Problem

When FreeSurfer is auto-detected (the `add_home == TRUE` branch of `get_fs()`),
the returned shell command begins with a stray `;` and contains a `; ;` run, e.g.:

```
; export FREESURFER_HOME='/usr/local/freesurfer'; source '/usr/local/freesurfer/FreeSurferEnv.sh' || true ; ; export FSF_OUTPUT_FORMAT=nii.gz; ${FREESURFER_HOME}/bin/mri_vol2surf ...
```

Running this via `bash -c` fails with `syntax error near unexpected token ';'`.

## Cause

In the `add_home` branch the parts vector starts with the empty `cmd <- ""`
element, and `sh_file_cmd` already ends in `" ; "`. Joining with
`collapse = "; "` therefore produces a leading `;` (from the empty element) and
a `; ;` (from `sh_file_cmd`'s own terminator plus the collapse separator). The
`!add_home` branch already filters empties with `nzchar()`, so it is unaffected —
which is why this only reproduces when FreeSurfer is found by default rather than
via an explicit `FREESURFER_HOME`.

## Fix

Route both branches through a small `collapse_fs_cmd()` helper that drops empty
parts and collapses leading / repeated `;` separators. Output is now:

```
export FREESURFER_HOME='...'; source '...' || true; export FSF_OUTPUT_FORMAT=nii; ${FREESURFER_HOME}/bin/
```

## Tests

Adds a regression test asserting `get_fs()` emits no leading or doubled
semicolon. Full suite green (860 tests pass).

Surfaced downstream while running a volume-to-surface pipeline; the malformed
command aborted `mri_vol2surf` at the surface-projection step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)